### PR TITLE
External errors and validate on visit

### DIFF
--- a/src/angular-validator.js
+++ b/src/angular-validator.js
@@ -199,7 +199,7 @@ angular.module('angularValidator').directive('angularValidator',
                         // If add-message-to-id is defined, use the element with this id to add error message to.
                         var elementToAddTo = angular.element(document.getElementById(element.attributes['add-message-to-id'].value));
                         // Add the error message to
-                        elementToAddAfter.append(message);
+                        elementToAddTo.append(message);
                     }
                     else {
                         // Add the error message after

--- a/src/angular-validator.js
+++ b/src/angular-validator.js
@@ -76,7 +76,8 @@ angular.module('angularValidator').directive('angularValidator',
                 // Setup $watch on a single formfield
                 function setupWatch(elementToWatch) {
                     // If element is set to validate on blur then update the element on blur
-                    if ("validate-on" in elementToWatch.attributes && elementToWatch.attributes["validate-on"].value === "blur") {
+                    if ("validate-on" in elementToWatch.attributes
+                        && ["blur", "visit"].indexOf(elementToWatch.attributes["validate-on"].value) > -1) {
                         angular.element(elementToWatch).on('blur', function() {
                             updateValidationMessage(elementToWatch);
                             updateValidationClass(elementToWatch);
@@ -96,7 +97,15 @@ angular.module('angularValidator').directive('angularValidator',
                                 // Determine if the element in question is to be updated on blur
                                 var isDirtyElement = "validate-on" in elementToWatch.attributes && elementToWatch.attributes["validate-on"].value === "dirty";
 
+                                // Determine if the element in question is to be updated on being touched
+                                var isTouchedElement = "validate-on" in elementToWatch.attributes && elementToWatch.attributes["validate-on"].value === "visit";
+
                                 if (isDirtyElement){
+                                    updateValidationMessage(elementToWatch);
+                                    updateValidationClass(elementToWatch);
+                                }
+                                // Only check element on dirty if it's been touched
+                                else if (isTouchedElement && scopeForm[elementToWatch.name].$touched) {
                                     updateValidationMessage(elementToWatch);
                                     updateValidationClass(elementToWatch);
                                 }

--- a/src/angular-validator.js
+++ b/src/angular-validator.js
@@ -171,26 +171,39 @@ angular.module('angularValidator').directive('angularValidator',
 
 
                     // Only add validation messages if the form field is $dirty or the form has been submitted
-                    if (scopeElementModel.$dirty || scope[element.form.name].submitted) {
+                    if (scopeElementModel.$dirty || (scope[element.form.name] && scope[element.form.name].submitted)) {
                         if (scopeElementModel.$error.required) {
                             // If there is a custom required message display it
                             if ("required-message" in element.attributes) {
-                                addErrorMessageAfter(element, generateErrorMessage(element.attributes['required-message'].value));
+                                addErrorMessage(element, generateErrorMessage(element.attributes['required-message'].value));
                             }
                             // Display the default required message
                             else {
-                                addErrorMessageAfter(element, generateErrorMessage(defaultRequiredMessage));
+                                addErrorMessage(element, generateErrorMessage(defaultRequiredMessage));
                             }
                         } else if (!scopeElementModel.$valid) {
                             // If there is a custom validation message add it
                             if ("invalid-message" in element.attributes) {
-                                addErrorMessageAfter(element, generateErrorMessage(element.attributes['invalid-message'].value));
+                                addErrorMessage(element, generateErrorMessage(element.attributes['invalid-message'].value));
                             }
                             // Display the default error message
                             else {
-                                addErrorMessageAfter(element, generateErrorMessage(defaultInvalidMessage));
+                                addErrorMessage(element, generateErrorMessage(defaultInvalidMessage));
                             }
                         }
+                    }
+                }
+                
+                function addErrorMessage(element, message) {
+                    if ("add-message-to-id" in element.attributes) {
+                        // If add-message-to-id is defined, use the element with this id to add error message to.
+                        var elementToAddTo = angular.element(document.getElementById(element.attributes['add-message-to-id'].value));
+                        // Add the error message to
+                        elementToAddAfter.append(message);
+                    }
+                    else {
+                        // Add the error message after
+                        addErrorMessageAfter(element, message);
                     }
                 }
 
@@ -219,7 +232,10 @@ angular.module('angularValidator').directive('angularValidator',
                 // Returns the validation message element or False
                 function isValidationMessagePresent(element) {
                     var elementSiblings;
-                    if ("add-message-after-id" in element.attributes) {
+                    if ("add-message-to-id" in element.attributes) {
+                        elementSiblings = angular.element(document.getElementById(element.attributes['add-message-to-id'].value)).children();
+                    }
+                    else if ("add-message-after-id" in element.attributes) {
                         elementSiblings = angular.element(document.getElementById(element.attributes['add-message-after-id'].value)).parent().children();
                     }
                     else {


### PR DESCRIPTION
Building on top of work by  FloMaetschke: can append error messages to an element with an id.

validate-on="visit" will validate on blur after a field has been visited
